### PR TITLE
fix: safely detect changes before committing

### DIFF
--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Git commit and push files
         run: |
-          if [ -n $(git status --porcelain) ]; then
+          if [ -n "$(git status --porcelain)" ]; then
             git config --global user.name "GitHub Actions Bot"
             git config --global user.email "<>"
             git add -A


### PR DESCRIPTION
## Summary
- use `git status --porcelain` with quotes to safely skip committing when no changes exist

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b9a1666b90832a93b5ae301e9696fa